### PR TITLE
Remove traceback

### DIFF
--- a/openprocurement/bot/identification/databridge/scanner.py
+++ b/openprocurement/bot/identification/databridge/scanner.py
@@ -56,7 +56,7 @@ class Scanner(Greenlet):
             return response
         else:
             assert 'descending' not in params
-            gevent.wait([self.initialization_event])
+            self.initialization_event.wait()
             params['offset'] = self.initial_sync_point['forward_offset']
             logger.info("Starting forward sync from offset {}".format(params['offset']))
             return self.tenders_sync_client.sync_tenders(params, extra_headers={'X-Client-Request-ID': generate_req_id()})

--- a/openprocurement/bot/identification/databridge/scanner.py
+++ b/openprocurement/bot/identification/databridge/scanner.py
@@ -118,9 +118,10 @@ class Scanner(Greenlet):
         except Exception as e:
             logger.warning('Backward worker died!', extra=journal_context({"MESSAGE_ID": DATABRIDGE_WORKER_DIED}, {}))
             logger.exception(e)
-            raise e
+            return False
         else:
             logger.info('Backward data sync finished.')
+            return True
 
     def _start_synchronization_workers(self):
         logger.info('Scanner starting forward and backward sync workers')
@@ -142,7 +143,7 @@ class Scanner(Greenlet):
             while not self.exit:
                 gevent.sleep(self.delay)
                 if forward_worker.dead or (backward_worker.dead and
-                                           not backward_worker.successful()):
+                                           not backward_worker.value):
                     self._restart_synchronization_workers()
                     backward_worker, forward_worker = self.jobs
         except Exception as e:

--- a/openprocurement/bot/identification/tests/edr_handler.py
+++ b/openprocurement/bot/identification/tests/edr_handler.py
@@ -200,8 +200,11 @@ class TestEdrHandlerWorker(unittest.TestCase):
                      [{'text': '', 'status_code': 402},
                       {'text': '', 'status_code': 402},
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]}, 'status_code': 200}])
+        mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[0]),
+                     json={'data': {}}, status_code=200)
 
         edrpou_codes_queue = Queue(10)
+        edr_ids_queue = Queue(10)
         check_queue = Queue(10)
 
         expected_result = []
@@ -210,9 +213,9 @@ class TestEdrHandlerWorker(unittest.TestCase):
             award_id = uuid.uuid4().hex
             edr_ids = [str(random.randrange(10000000, 99999999)) for _ in range(2)]
             edrpou_codes_queue.put(Data(tender_id, award_id, edr_ids[i], "awards", None, None))  # data
-            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [local_edr_ids[i]], None))  # result
+            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [local_edr_ids[i]], {}))  # result
 
-        worker = EdrHandler.spawn(proxy_client, edrpou_codes_queue, check_queue, MagicMock(), MagicMock())
+        worker = EdrHandler.spawn(proxy_client, edrpou_codes_queue, edr_ids_queue, check_queue, MagicMock())
 
         self.assertEqual(check_queue.get(), expected_result[0])
         worker.shutdown()

--- a/openprocurement/bot/identification/tests/scanner.py
+++ b/openprocurement/bot/identification/tests/scanner.py
@@ -20,11 +20,13 @@ from openprocurement.bot.identification.tests.utils import custom_sleep
 class TestScannerWorker(unittest.TestCase):
 
     def test_init(self):
-        worker = Scanner.spawn(None, None)
+        client = MagicMock()
+        tender_queue = Queue(10)
+        worker = Scanner.spawn(client, tender_queue)
         self.assertGreater(datetime.datetime.now().isoformat(),
                            worker.start_time.isoformat())
-        self.assertEqual(worker.tenders_sync_client, None)
-        self.assertEqual(worker.filtered_tender_ids_queue, None)
+        self.assertEqual(worker.tenders_sync_client, client)
+        self.assertEqual(worker.filtered_tender_ids_queue, tender_queue)
         self.assertEqual(worker.increment_step, 1)
         self.assertEqual(worker.decrement_step, 1)
         self.assertEqual(worker.delay, 15)

--- a/openprocurement/bot/identification/tests/scanner.py
+++ b/openprocurement/bot/identification/tests/scanner.py
@@ -178,10 +178,10 @@ class TestScannerWorker(unittest.TestCase):
                       'data': [{'status': "active.pre-qualification",
                                 "id": tenders_id[1],
                                 'procurementMethodType': 'aboveThresholdEU'}]}),
+            ResourceError(http_code=403),
             munchify({'prev_page': {'offset': '1235'},
                       'next_page': {'offset': '1236'},
                       'data': []}),
-            ResourceError(http_code=403),
             munchify({'prev_page': {'offset': '1236'},
                       'next_page': {'offset': '1237'},
                       'data': [{'status': "active.pre-qualification",
@@ -276,20 +276,16 @@ class TestScannerWorker(unittest.TestCase):
         gevent_sleep.side_effect = custom_sleep
         tender_queue = Queue(10)
         client = MagicMock()
-        tenders_id = [uuid.uuid4().hex for i in range(3)]
+        tenders_id = [uuid.uuid4().hex for i in range(4)]
         client.sync_tenders.side_effect = [
             munchify({'prev_page': {'offset': '123'},
                       'next_page': {'offset': '1234'},
                       'data': [{'status': "active.pre-qualification",
-                                'procurementMethodType': 'aboveThresholdEU'}]}),
+                                'procurementMethodType': 'aboveThresholdEU',
+                                'id': tenders_id[0]}]}),
             munchify({'prev_page': {'offset': '123'},
                       'next_page': {'offset': '1234'},
                       'data': []}),
-            munchify({'prev_page': {'offset': '123'},
-                      'next_page': {'offset': '1234'},
-                      'data': [{'status': "active.pre-qualification",
-                                "id": tenders_id[0],
-                                'procurementMethodType': 'aboveThresholdEU'}]}),
             munchify({'prev_page': {'offset': '123'},
                       'next_page': {'offset': '1234'},
                       'data': [{'status': "active.pre-qualification",
@@ -298,6 +294,7 @@ class TestScannerWorker(unittest.TestCase):
             munchify({'prev_page': {'offset': '123'},
                       'next_page': {'offset': '1234'},
                       'data': [{'status': "active.pre-qualification",
+                                "id": tenders_id[2],
                                 'procurementMethodType': 'aboveThresholdEU'}]}),
             munchify({'prev_page': {'offset': '123'},
                       'next_page': {'offset': '1234'},
@@ -308,7 +305,7 @@ class TestScannerWorker(unittest.TestCase):
             munchify({'prev_page': {'offset': '1234'},
                       'next_page': {'offset': '1234'},
                       'data': [{'status': "active.pre-qualification",
-                                "id": tenders_id[2],
+                                "id": tenders_id[3],
                                 'procurementMethodType': 'aboveThresholdEU'}]})
         ]
 


### PR DESCRIPTION
Прибрали всі Traceback, окрім 1 він потрібен для перевірки (https://github.com/ITVaan/openprocurement.bot.identification/blob/master/openprocurement/bot/identification/databridge/scanner.py#L121) що при backward died, ми перезапустимо синхронизацію.