### PR TITLE
Fix retry header

### DIFF
--- a/openprocurement/bot/identification/databridge/edr_handler.py
+++ b/openprocurement/bot/identification/databridge/edr_handler.py
@@ -258,7 +258,7 @@ class EdrHandler(Greenlet):
     def handle_status_response(self, response, tender_id):
         """Process unsuccessful request"""
         if response.status_code == 429:
-            self.until_too_many_requests_event.wait(response.headers['Retry-After'])
+            self.until_too_many_requests_event.wait(response.headers.get('Retry-After', self.delay))
         elif response.status_code == 403 and response.json().get('errors')[0].get('description') == [{'message': 'Payment required.', 'code': 5}]:
             logger.warning('Payment required for requesting info to EDR. '
                            'Error description: {err}'.format(err=response.text),

--- a/openprocurement/bot/identification/databridge/edr_handler.py
+++ b/openprocurement/bot/identification/databridge/edr_handler.py
@@ -222,11 +222,11 @@ class EdrHandler(Greenlet):
             for edr_id in tender_data.edr_ids:
                 try:
                     response = self.get_edr_details_request(edr_id)
-                except RetryException:
+                except RetryException as re:
                     self.retry_edr_ids_queue.put((Data(tender_data.tender_id, tender_data.item_id, tender_data.code,
                                                        tender_data.item_name, [edr_id], tender_data.file_content)))
-                    logger.info('Put tender {} with {} id {} to retry_edr_ids_queue'.format(
-                        tender_data.tender_id, tender_data.item_name, tender_data.item_id),
+                    logger.info('Put tender {} with {} id {} to retry_edr_ids_queue.Error response {}'.format(
+                        tender_data.tender_id, tender_data.item_name, tender_data.item_id, re.args[1].json().get('errors')),
                         extra=journal_context(params={"TENDER_ID": tender_data.tender_id}))
                     gevent.sleep(0)
                 else:

--- a/openprocurement/bot/identification/tests/edr_handler.py
+++ b/openprocurement/bot/identification/tests/edr_handler.py
@@ -83,40 +83,6 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEqual(edrpou_codes_queue.qsize(), 0, 'Queue must be empty')
         self.assertEqual(mrequest.call_count, 4)
 
-    @requests_mock.Mocker()
-    @patch('gevent.sleep')
-    def test_proxy_client_401(self, mrequest, gevent_sleep):
-        """ After 401 need restart worker """
-        local_edr_ids = get_random_edr_ids(2)
-        gevent_sleep.side_effect = custom_sleep
-        proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
-        mrequest.get("{uri}".format(uri=proxy_client.verify_url),
-                     [{'text': '', 'status_code': 401},
-                      {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]}, 'status_code': 200},
-                      {'json': {'data': [{'x_edrInternalId': local_edr_ids[1]}]}, 'status_code': 200}])
-        mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[0]),
-                     json={'data': {}}, status_code=200)
-        mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[1]),
-                     json={'data': {}}, status_code=200)
-
-        edrpou_codes_queue = Queue(10)
-        edr_ids_queue = Queue(10)
-        check_queue = Queue(10)
-        expected_result = []
-        for i in range(2):
-            tender_id = uuid.uuid4().hex
-            award_id = uuid.uuid4().hex
-            edr_ids = [str(random.randrange(10000000, 99999999)) for _ in range(2)]
-            edrpou_codes_queue.put(Data(tender_id, award_id, edr_ids[i], "awards", None, None))  # data
-            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [local_edr_ids[i]], {}))  # result
-
-        worker = EdrHandler.spawn(proxy_client, edrpou_codes_queue, edr_ids_queue, check_queue, MagicMock())
-
-        for result in expected_result:
-            self.assertEqual(check_queue.get(), result)
-
-        worker.shutdown()
-        self.assertEqual(edrpou_codes_queue.qsize(), 0, 'Queue must be empty')
 
     @requests_mock.Mocker()
     @patch('gevent.sleep')
@@ -126,8 +92,8 @@ class TestEdrHandlerWorker(unittest.TestCase):
         gevent_sleep.side_effect = custom_sleep
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{uri}".format(uri=proxy_client.verify_url),
-                     [{'text': '', 'status_code': 429, 'headers': {'Retry-After': '10'}},
-                      {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]},'status_code': 200},
+                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 403, 'headers': {'Retry-After': '10'}},
+                      {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]}, 'status_code': 200},
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[1]}]}, 'status_code': 200}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[0]),
                      json={'data': {}}, status_code=200)
@@ -157,12 +123,13 @@ class TestEdrHandlerWorker(unittest.TestCase):
     @requests_mock.Mocker()
     @patch('gevent.sleep')
     def test_proxy_client_402(self, mrequest, gevent_sleep):
-        """First request returns 402 status code."""
+        """First request returns Edr API returns to proxy 402 status code with messages."""
         gevent_sleep.side_effect = custom_sleep
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         local_edr_ids = get_random_edr_ids(2)
         mrequest.get("{uri}".format(uri=proxy_client.verify_url),
-                     [{'text': '', 'status_code': 402},  # pay for me
+                     [{'json': {'errors': [{'description': [{'message': 'Payment required.', 'code': 5}]}]},
+                       'status_code': 403},  # pay for me
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]}, 'status_code': 200},
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[1]}]}, 'status_code': 200}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[0]),
@@ -193,13 +160,13 @@ class TestEdrHandlerWorker(unittest.TestCase):
     @requests_mock.Mocker()
     @patch('gevent.sleep')
     def test_retry_get_edr_id(self, mrequest, gevent_sleep):
-        """First and second response returns 402 status code. Tests retry for get_edr_id worker"""
+        """First and second response returns 403 status code. Tests retry for get_edr_id worker"""
         gevent_sleep.side_effect = custom_sleep
         local_edr_ids = get_random_edr_ids(1)
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{uri}".format(uri=proxy_client.verify_url),
-                     [{'text': '', 'status_code': 402},
-                      {'text': '', 'status_code': 402},
+                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 403},
+                      {'json': {'errors': [{'description': ''}]}, 'status_code': 403},
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]}, 'status_code': 200}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[0]),
                      json={'data': {}}, status_code=200)
@@ -325,7 +292,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
     @requests_mock.Mocker()
     @patch('gevent.sleep')
     def test_retry_get_edr_details_two_ids(self, mrequest, gevent_sleep):
-        """Accept two ids in /verify request. Then accept 200 response for first id, and 402 and 200
+        """Accept two ids in /verify request. Then accept 200 response for first id, and 403 and 200
         responses for second id. Check retry_get_edr_details job"""
         gevent_sleep.side_effect = custom_sleep
         tender_id = uuid.uuid4().hex
@@ -335,7 +302,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
                      json={'data': [{'x_edrInternalId': '321'}, {'x_edrInternalId': '322'}]}, status_code=200)
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321), json={'data': {}}, status_code=200)
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=322),
-                     [{'text': '', 'status_code': 402},
+                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 403},
                       {'json': {'data': {}}, 'status_code': 200}])
         edrpou_codes_queue = Queue(10)
         edr_ids_queue = Queue(10)
@@ -466,7 +433,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{url}".format(url=proxy_client.verify_url), json={'data': [{'x_edrInternalId': '321'}]}, status_code=200)
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321),
-                     [{'text': '', 'status_code': 402},
+                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 403},
                       {'json': [], 'status_code': 200},  # list instead of dict in data
                       {'json': {'data': {}}, 'status_code': 200}])
         edrpou_codes_queue = Queue(10)
@@ -491,19 +458,19 @@ class TestEdrHandlerWorker(unittest.TestCase):
     @requests_mock.Mocker()
     @patch('gevent.sleep')
     def test_retry_get_edr_details(self, mrequest, gevent_sleep):
-        """Accept 6 times errors (403 and 402 status codes) in response while requesting /details"""
+        """Accept 6 times errors in response while requesting /details"""
         gevent_sleep.side_effect = custom_sleep
         tender_id = uuid.uuid4().hex
         award_id = uuid.uuid4().hex
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{url}".format(url=proxy_client.verify_url), json={'data': [{'x_edrInternalId': '321'}]}, status_code=200)
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321),
-                     [{'json': '', 'status_code': 403},
-                      {'json': '', 'status_code': 402},
-                      {'json': '', 'status_code': 402},
-                      {'json': '', 'status_code': 402},
-                      {'json': '', 'status_code': 402},
-                      {'json': '', 'status_code': 402},
+                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 403},
+                      {'json': {'errors': [{'description': ''}]}, 'status_code': 403},
+                      {'json': {'errors': [{'description': ''}]}, 'status_code': 403},
+                      {'json': {'errors': [{'description': ''}]}, 'status_code': 403},
+                      {'json': {'errors': [{'description': ''}]}, 'status_code': 403},
+                      {'json': {'errors': [{'description': ''}]}, 'status_code': 403},
                       {'json': {'data': {}}, 'status_code': 200}])
         edrpou_codes_queue = Queue(10)
         edr_ids_queue = Queue(10)
@@ -526,7 +493,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
     @requests_mock.Mocker()
     @patch('gevent.sleep')
     def test_retry_5_times_get_edr_id(self, mrequest, gevent_sleep):
-        """Accept 6 times errors (403 and 402 status codes) in response while requesting /verify"""
+        """Accept 6 times errors in response while requesting /verify"""
         gevent_sleep.side_effect = custom_sleep
         tender_id = uuid.uuid4().hex
         award_id = uuid.uuid4().hex

--- a/openprocurement/bot/identification/tests/edr_handler.py
+++ b/openprocurement/bot/identification/tests/edr_handler.py
@@ -92,7 +92,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         gevent_sleep.side_effect = custom_sleep
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{uri}".format(uri=proxy_client.verify_url),
-                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 403, 'headers': {'Retry-After': '10'}},
+                     [{'json': {'errors': [{'description': ''}]}, 'status_code': 429, 'headers': {'Retry-After': '10'}},
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[0]}]}, 'status_code': 200},
                       {'json': {'data': [{'x_edrInternalId': local_edr_ids[1]}]}, 'status_code': 200}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=local_edr_ids[0]),


### PR DESCRIPTION
Зміни пов'язані з [ПР](https://github.com/openprocurement/openprocurement.integrations.edr/pull/30)
Оскільки проксі-сервер повертає не 429, а 403 з header Retry-After, змінили код та тести. Також змінили поведінку бота з 401, 402 статусів на 403(проксі повертає тільки 403 з відповідним повідомленням) та тести до них. 