### PR TITLE
fix no global name re

### DIFF
--- a/openprocurement/bot/identification/databridge/edr_handler.py
+++ b/openprocurement/bot/identification/databridge/edr_handler.py
@@ -222,7 +222,7 @@ class EdrHandler(Greenlet):
             for edr_id in tender_data.edr_ids:
                 try:
                     response = self.get_edr_details_request(edr_id)
-                except RetryException:
+                except RetryException as re:
                     self.retry_edr_ids_queue.put((Data(tender_data.tender_id, tender_data.item_id, tender_data.code,
                                                        tender_data.item_name, [edr_id], tender_data.file_content)))
                     logger.info('Put tender {} with {} id {} to retry_edr_ids_queue.Error response {}'.format(


### PR DESCRIPTION
Зміни згідно [issue](https://github.com/openprocurement/openprocurement.bot.identification/issues/42).  Мали: global name 're' is not define.
