### PR TITLE
Bugs fix

### DIFF
--- a/openprocurement/bot/identification/databridge/bridge.py
+++ b/openprocurement/bot/identification/databridge/bridge.py
@@ -119,6 +119,8 @@ class EdrDataBridge(object):
                                    upload_to_tender_queue=self.upload_to_tender_queue,
                                    processing_items=self.processing_items,
                                    doc_service_client=self.doc_service_client,
+                                   increment_step=self.increment_step,
+                                   decrement_step=self.decrement_step,
                                    delay=self.delay)
 
     def config_get(self, name):

--- a/openprocurement/bot/identification/databridge/edr_handler.py
+++ b/openprocurement/bot/identification/databridge/edr_handler.py
@@ -220,7 +220,7 @@ class EdrHandler(Greenlet):
                         file_content['meta'].update({"version": version})  # add filed meta.version
                         file_content['meta']['sourceRequests'].append(response.headers['X-Request-ID'])
                         data = Data(tender_data.tender_id, tender_data.item_id, tender_data.code,
-                                    tender_data.item_name, tender_data.edr_ids[:], file_content)
+                                    tender_data.item_name, tender_data.edr_ids, file_content)
                         self.upload_to_doc_service_queue.put(data)
                         logger.info('Successfully created file for {} doc_id: {}.'.format(
                             data_string(tender_data), document_id),
@@ -253,8 +253,7 @@ class EdrHandler(Greenlet):
                                               params={"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id}))
             self.until_too_many_requests_event.wait()
             document_id = tender_data.file_content['meta']['id']
-            while len(tender_data.edr_ids):
-                edr_id = tender_data.edr_ids[0]
+            for edr_id in tender_data.edr_ids:
                 try:
                     response = self.get_edr_details_request(edr_id, document_id)
                     if response.headers.get('X-Request-ID'):
@@ -265,9 +264,7 @@ class EdrHandler(Greenlet):
                         data_string(tender_data), document_id, re.args[1].json().get('errors')),
                         extra=journal_context(params={"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id,
                                                       "DOCUMENT_ID": document_id}))
-                    self.retry_edr_ids_queue.put(self.retry_edr_ids_queue.get())
                     gevent.sleep(0)
-                    break
                 else:
                     if response.status_code == 429:
                         seconds_to_wait = response.headers.get('Retry-After', self.delay)
@@ -280,24 +277,22 @@ class EdrHandler(Greenlet):
                             data_string(tender_data), document_id, "Not a dictionary"),
                             extra=journal_context(params={"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id,
                                                           "DOCUMENT_ID": document_id}))
-                        self.retry_edr_ids_queue.put(self.retry_edr_ids_queue.get())
-                        break
                     else:
                         file_content = response.json()
                         file_content['meta'].update(tender_data.file_content['meta'])
                         file_content['meta'].update({"version": version})  # add filed meta.version
                         data = Data(tender_data.tender_id, tender_data.item_id, tender_data.code,
-                                    tender_data.item_name, tender_data.edr_ids[:], file_content)
+                                    tender_data.item_name, tender_data.edr_ids, file_content)
                         self.upload_to_doc_service_queue.put(data)
                         tender_data.edr_ids.remove(edr_id)
-                        if len(tender_data.edr_ids) == 0:
-                            self.retry_edr_ids_queue.get()
-                            continue
                         logger.info('Successfully created file for tender {} doc_id {} in retry.'.format(
                             data_string(tender_data), document_id),
                             extra=journal_context({"MESSAGE_ID": DATABRIDGE_SUCCESS_CREATE_FILE},
                                                   params={"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id,
                                                           "DOCUMENT_ID": document_id}))
+            if len(tender_data.edr_ids) == 0:
+                self.retry_edr_ids_queue.get()
+                continue
             gevent.sleep(0)
 
     @retry(stop_max_attempt_number=5, wait_exponential_multiplier=1000)

--- a/openprocurement/bot/identification/databridge/edr_handler.py
+++ b/openprocurement/bot/identification/databridge/edr_handler.py
@@ -42,8 +42,8 @@ class EdrHandler(Greenlet):
         self.upload_to_doc_service_queue = upload_to_doc_service_queue
 
         # retry queues for workers
-        self.retry_edrpou_codes_queue = Queue(maxsize=2)
-        self.retry_edr_ids_queue = Queue(maxsize=1)
+        self.retry_edrpou_codes_queue = Queue(maxsize=500)
+        self.retry_edr_ids_queue = Queue(maxsize=500)
 
         # blockers
         self.until_too_many_requests_event = gevent.event.Event()

--- a/openprocurement/bot/identification/tests/edr_handler.py
+++ b/openprocurement/bot/identification/tests/edr_handler.py
@@ -422,7 +422,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id,
                                      item_id=award_id,
-                                     code='123', item_name='awards', edr_ids=['322'],
+                                     code='123', item_name='awards', edr_ids=[],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": '{}.{}.{}'.format(document_id, 2, 2),
                                                                         "version": version, 'author': author,
@@ -553,7 +553,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=['321'],
+                                     edr_ids=[],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": document_id, "version": version, 'author': author,
                                                                         'sourceRequests': [
@@ -597,7 +597,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=['321'],
+                                     edr_ids=[],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": document_id, "version": version, 'author': author,
                                                                         'sourceRequests': [
@@ -647,7 +647,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=['321'],
+                                     edr_ids=[],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": document_id, "version": version, 'author': author,
                                                                         'sourceRequests': [
@@ -722,7 +722,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                           Data(tender_id=tender_id, item_id=award_id,
                                code='123', item_name='awards',
-                               edr_ids=['321', '322'],
+                               edr_ids=['322'],
                                file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                   "id": document_id, "version": version,
                                                                   'author': author,
@@ -732,7 +732,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                           Data(tender_id=tender_id, item_id=award_id,
                                code='123', item_name='awards',
-                               edr_ids=['322'],
+                               edr_ids=[],
                                file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                   "id": document_id, "version": version,
                                                                   'author': author,
@@ -807,7 +807,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{url}".format(url=proxy_client.verify_url),
                      [{'json': {'errors': [{'description': [{u'message': u'Gateway Timeout Error'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_req_id[0]}},
-                      {'json': {'data': [{'x_edrInternalId': '321'}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
+                      {'json': {'data': [{'x_edrInternalId': 321}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321),
                      [{'json': {'errors': [{'description': [{u'message': u'Gateway Timeout Error'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_details_req_id[0]}},
                       {'json': {'data': {'id': 321}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_details_req_id[1]}}])
@@ -820,7 +820,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=['321'],
+                                     edr_ids=[],
                                      file_content={'data': {'id': 321}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                                 "id": document_id, "version": version, 'author': author,
                                                                                  'sourceRequests': [
@@ -994,7 +994,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{url}".format(url=proxy_client.verify_url),
                      [{'json': {'errors': [{'description': [{u'message': u'Forbidden'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_req_id[0]}},
-                      {'json': {'data': [{'x_edrInternalId': '321'}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
+                      {'json': {'data': [{'x_edrInternalId': 321}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321),
                      [{'json': {'errors': [{'description': [{u'message': u'Forbidden'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_details_req_id[0]}},
                       {'json': {'data': {'id': 321}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_details_req_id[1]}}])
@@ -1007,7 +1007,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=['321'],
+                                     edr_ids=[],
                                      file_content={'data': {'id': 321},
                                                    "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                             "id": document_id, "version": version, 'author': author,
@@ -1228,7 +1228,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
             tender_id = uuid.uuid4().hex
             award_id = uuid.uuid4().hex
             edr_ids = [str(random.randrange(10000000, 99999999)) for _ in range(2)]
-            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [local_edr_ids[i]],
+            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [],
                                         {'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00", "id": document_ids[i],
                                                               "version": version, 'author': author,
                                                               'sourceRequests': [

--- a/openprocurement/bot/identification/tests/edr_handler.py
+++ b/openprocurement/bot/identification/tests/edr_handler.py
@@ -422,7 +422,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id,
                                      item_id=award_id,
-                                     code='123', item_name='awards', edr_ids=[],
+                                     code='123', item_name='awards', edr_ids=['322'],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": '{}.{}.{}'.format(document_id, 2, 2),
                                                                         "version": version, 'author': author,
@@ -553,7 +553,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=[],
+                                     edr_ids=['321'],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": document_id, "version": version, 'author': author,
                                                                         'sourceRequests': [
@@ -597,7 +597,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=[],
+                                     edr_ids=['321'],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": document_id, "version": version, 'author': author,
                                                                         'sourceRequests': [
@@ -647,7 +647,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=[],
+                                     edr_ids=['321'],
                                      file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                         "id": document_id, "version": version, 'author': author,
                                                                         'sourceRequests': [
@@ -722,7 +722,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                           Data(tender_id=tender_id, item_id=award_id,
                                code='123', item_name='awards',
-                               edr_ids=['322'],
+                               edr_ids=['321', '322'],
                                file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                   "id": document_id, "version": version,
                                                                   'author': author,
@@ -732,7 +732,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                           Data(tender_id=tender_id, item_id=award_id,
                                code='123', item_name='awards',
-                               edr_ids=[],
+                               edr_ids=['322'],
                                file_content={'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                   "id": document_id, "version": version,
                                                                   'author': author,
@@ -807,7 +807,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{url}".format(url=proxy_client.verify_url),
                      [{'json': {'errors': [{'description': [{u'message': u'Gateway Timeout Error'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_req_id[0]}},
-                      {'json': {'data': [{'x_edrInternalId': 321}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
+                      {'json': {'data': [{'x_edrInternalId': '321'}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321),
                      [{'json': {'errors': [{'description': [{u'message': u'Gateway Timeout Error'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_details_req_id[0]}},
                       {'json': {'data': {'id': 321}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_details_req_id[1]}}])
@@ -820,7 +820,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=[],
+                                     edr_ids=['321'],
                                      file_content={'data': {'id': 321}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                                                 "id": document_id, "version": version, 'author': author,
                                                                                  'sourceRequests': [
@@ -994,7 +994,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         proxy_client = ProxyClient(host='127.0.0.1', port='80', user='', password='')
         mrequest.get("{url}".format(url=proxy_client.verify_url),
                      [{'json': {'errors': [{'description': [{u'message': u'Forbidden'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_req_id[0]}},
-                      {'json': {'data': [{'x_edrInternalId': 321}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
+                      {'json': {'data': [{'x_edrInternalId': '321'}], "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_req_id[1]}}])
         mrequest.get("{url}/{id}".format(url=proxy_client.details_url, id=321),
                      [{'json': {'errors': [{'description': [{u'message': u'Forbidden'}]}]}, 'status_code': 403, 'headers': {'X-Request-ID': edr_details_req_id[0]}},
                       {'json': {'data': {'id': 321}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00"}}, 'status_code': 200, 'headers': {'X-Request-ID': edr_details_req_id[1]}}])
@@ -1007,7 +1007,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.assertEquals(upload_to_doc_service_queue.get(),
                                 Data(tender_id=tender_id, item_id=award_id,
                                      code='123', item_name='awards',
-                                     edr_ids=[],
+                                     edr_ids=['321'],
                                      file_content={'data': {'id': 321},
                                                    "meta": {"sourceDate": "2017-04-25T11:56:36+00:00",
                                                             "id": document_id, "version": version, 'author': author,
@@ -1228,7 +1228,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
             tender_id = uuid.uuid4().hex
             award_id = uuid.uuid4().hex
             edr_ids = [str(random.randrange(10000000, 99999999)) for _ in range(2)]
-            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [],
+            expected_result.append(Data(tender_id, award_id, edr_ids[i], "awards", [local_edr_ids[i]],
                                         {'data': {}, "meta": {"sourceDate": "2017-04-25T11:56:36+00:00", "id": document_ids[i],
                                                               "version": version, 'author': author,
                                                               'sourceRequests': [


### PR DESCRIPTION
Виправлено незначні помилки 
- передача у  worker upload_file значень increment_step,та decrement_step з загальних налаштувань
- скоректовано формування суфіксів для document_id. Проблема виникала у випадку, коли ЄДР повертав більше одного документу і при отриманні деталізації по першому з них виникала помилка - це призводило до присвоєння обом файлам однакового id (поле meta.id файлу edr_identification.yaml), по логам визначили що було таких два тендери (один з них http://public.api.openprocurement.org/api/2.3/tenders/052d0096cc76403ca3d3c6b2a151a157/qualifications/cddb4fadbe734604826f75449d581828).
- розширено та підправлено логування 