### PR TITLE
Sandbox filter

### DIFF
--- a/openprocurement/bot/identification/client.py
+++ b/openprocurement/bot/identification/client.py
@@ -20,9 +20,10 @@ class ProxyClient(object):
 
         return response
 
-    def health(self):
+    def health(self, sandbox_mode):
         """Send request to the Proxy server to get whether its active"""
-        response = self.session.get(url=self.health_url, auth=(self.user, self.password), timeout=self.timeout)
+        response = self.session.get(url=self.health_url, auth=(self.user, self.password),
+                                    headers={"sandbox-mode": sandbox_mode}, timeout=self.timeout)
         if response.status_code == 200:
             return response
         raise requests.RequestException("{} {} {}".format(response.url, response.status_code, response.reason), response=response)

--- a/openprocurement/bot/identification/databridge/bridge.py
+++ b/openprocurement/bot/identification/databridge/bridge.py
@@ -58,6 +58,7 @@ class EdrDataBridge(object):
         self.decrement_step = self.config_get('decrement_step') or 1
         self.doc_service_host = self.config_get('doc_service_server')
         self.doc_service_port = self.config_get('doc_service_port') or 6555
+        self.sandbox_mode = os.environ.get('SANDBOX_MODE', 'False')
 
         # init clients
         self.tenders_sync_client = TendersClientSync('', host_url=ro_api_server, api_version=api_version)
@@ -137,10 +138,11 @@ class EdrDataBridge(object):
             return True
 
     def check_proxy(self):
+        """Check whether proxy is up and has the same sandbox mode (to prevent launching wrong pair of bot-proxy)"""
         try:
-            self.proxyClient.health()
+            self.proxyClient.health(self.sandbox_mode)
         except RequestException as e:
-            logger.info('Proxy server connection error, message {}'.format(e),
+            logger.info('Proxy server connection error, message {} {}'.format(e, self.sandbox_mode),
                         extra=journal_context({"MESSAGE_ID": DATABRIDGE_PROXY_SERVER_CONN_ERROR}, {}))
             raise e
         else:

--- a/openprocurement/bot/identification/tests/bridge.py
+++ b/openprocurement/bot/identification/tests/bridge.py
@@ -9,7 +9,7 @@ from mock import patch, MagicMock
 from restkit import RequestError, ResourceError
 
 from gevent.pywsgi import WSGIServer
-from bottle import Bottle, response
+from bottle import Bottle, response, request
 
 from openprocurement.bot.identification.databridge.bridge import EdrDataBridge
 from openprocurement_client.client import TendersClientSync, TendersClient
@@ -105,6 +105,8 @@ def doc_response():
 
 
 def proxy_response():
+    if request.headers.get("sandbox-mode") != "True":  # Imitation of health comparison
+        response.status = 400
     return response
 
 
@@ -198,14 +200,24 @@ class TestBridgeWorker(BaseServersTest):
 
     def test_proxy_server_failure(self):
         self.worker = EdrDataBridge(config)
+        self.worker.sandbox_mode = "True"
         self.proxy_server.stop()
         with self.assertRaises(RequestException):
             self.worker.check_proxy()
         self.proxy_server.start()
         self.assertTrue(self.worker.check_proxy())
 
+    def test_proxy_sandmox_mismatch(self):
+        self.worker = EdrDataBridge(config)
+        self.worker.sandbox_mode = "False"
+        with self.assertRaises(RequestException):
+            self.worker.check_proxy()
+        self.worker.sandbox_mode = "True"
+        self.assertTrue(self.worker.check_proxy())
+
     def test_proxy_server_success(self):
         self.worker = EdrDataBridge(config)
+        self.worker.sandbox_mode = "True"
         self.assertTrue(self.worker.check_proxy())
 
     def test_doc_service_failure(self):


### PR DESCRIPTION
Контроль допустимого режиму взаємодії боту та проксі (у випадку коли бот у режимі production, а проксі у режимі sandbox, то роботу боту буде припинено для запобігання завантаження порожніх довідок)
Частина логіки по https://github.com/openprocurement/openprocurement.integrations.edr/pull/44 