### PR TITLE
Intensity control requests

### DIFF
--- a/openprocurement/bot/identification/databridge/bridge.py
+++ b/openprocurement/bot/identification/databridge/bridge.py
@@ -27,6 +27,8 @@ from openprocurement.bot.identification.databridge.journal_msg_ids import (
     DATABRIDGE_RESTART_WORKER, DATABRIDGE_START, DATABRIDGE_DOC_SERVICE_CONN_ERROR,
     DATABRIDGE_PROXY_SERVER_CONN_ERROR)
 
+from openprocurement.bot.identification.databridge.sleep_change_value import APIRateController
+
 logger = logging.getLogger(__name__)
 
 
@@ -58,6 +60,7 @@ class EdrDataBridge(object):
         self.delay = self.config_get('delay') or 15
         self.increment_step = self.config_get('increment_step') or 1
         self.decrement_step = self.config_get('decrement_step') or 1
+        self.sleep_change_value = APIRateController(self.increment_step, self.decrement_step)
         self.doc_service_host = self.config_get('doc_service_server')
         self.doc_service_port = self.config_get('doc_service_port') or 6555
         self.sandbox_mode = os.environ.get('SANDBOX_MODE', 'False')
@@ -96,8 +99,7 @@ class EdrDataBridge(object):
                                tenders_sync_client=self.tenders_sync_client,
                                filtered_tender_ids_queue=self.filtered_tender_ids_queue,
                                services_not_available=self.services_not_available,
-                               increment_step=self.increment_step,
-                               decrement_step=self.decrement_step,
+                               sleep_change_value=self.sleep_change_value,
                                delay=self.delay)
 
         self.filter_tender = partial(FilterTenders.spawn,
@@ -107,8 +109,7 @@ class EdrDataBridge(object):
                                      processing_items=self.processing_items,
                                      services_not_available=self.services_not_available,
                                      processed_items=self.processed_items,
-                                     increment_step=self.increment_step,
-                                     decrement_step=self.decrement_step,
+                                     sleep_change_value=self.sleep_change_value,
                                      delay=self.delay)
 
         self.edr_handler = partial(EdrHandler.spawn,
@@ -127,8 +128,7 @@ class EdrDataBridge(object):
                                    processed_items=self.processed_items,
                                    doc_service_client=self.doc_service_client,
                                    services_not_available=self.services_not_available,
-                                   increment_step=self.increment_step,
-                                   decrement_step=self.decrement_step,
+                                   sleep_change_value=self.sleep_change_value,
                                    delay=self.delay)
 
     def config_get(self, name):

--- a/openprocurement/bot/identification/databridge/edr_handler.py
+++ b/openprocurement/bot/identification/databridge/edr_handler.py
@@ -205,7 +205,7 @@ class EdrHandler(Greenlet):
         response = self.proxyClient.verify(param, code, headers={'X-Client-Request-ID': document_id})
         if response.status_code not in (200, 429):
             logger.info(
-                'Get unsuccessful response {} in get_edr_id_request code={} document_id={}, header {}'.format(response.status_code, param, code, response.headers.get('X-Request-ID')))
+                'Get unsuccessful response {} in get_edr_id_request code={} document_id={}, header {}'.format(response.status_code, code, document_id, response.headers.get('X-Request-ID')))
             raise RetryException('Unsuccessful retry request to EDR.', response)
         return response
 

--- a/openprocurement/bot/identification/databridge/scanner.py
+++ b/openprocurement/bot/identification/databridge/scanner.py
@@ -23,9 +23,8 @@ class Scanner(Greenlet):
 
     pre_qualification_procurementMethodType = ('aboveThresholdEU', 'competitiveDialogueUA', 'competitiveDialogueEU')
     qualification_procurementMethodType = ('aboveThresholdUA', 'aboveThresholdUA.defense', 'aboveThresholdEU', 'competitiveDialogueUA.stage2', 'competitiveDialogueEU.stage2')
-    sleep_change_value = 0
 
-    def __init__(self, tenders_sync_client, filtered_tender_ids_queue, services_not_available, increment_step=1, decrement_step=1, delay=15):
+    def __init__(self, tenders_sync_client, filtered_tender_ids_queue, services_not_available, sleep_change_value, delay=15):
         super(Scanner, self).__init__()
         self.exit = False
         self.start_time = datetime.now()
@@ -39,8 +38,7 @@ class Scanner(Greenlet):
 
         # blockers
         self.initialization_event = Event()
-        self.increment_step = increment_step
-        self.decrement_step = decrement_step
+        self.sleep_change_value = sleep_change_value
         self.services_not_available = services_not_available
 
     @retry(stop_max_attempt_number=5, wait_exponential_multiplier=1000)
@@ -82,14 +80,14 @@ class Scanner(Greenlet):
                                 extra=journal_context({"MESSAGE_ID": DATABRIDGE_INFO},
                                                       params={"TENDER_ID": tender['id']}))
             logger.info('Sleep {} sync...'.format(direction), extra=journal_context({"MESSAGE_ID": DATABRIDGE_SYNC_SLEEP}))
-            gevent.sleep(self.delay + Scanner.sleep_change_value)
+            gevent.sleep(self.delay + self.sleep_change_value.time_between_requests)
             try:
                 response = self.tenders_sync_client.sync_tenders(params, extra_headers={'X-Client-Request-ID': generate_req_id()})
-                Scanner.sleep_change_value = Scanner.sleep_change_value - self.decrement_step if self.decrement_step < Scanner.sleep_change_value else 0
+                self.sleep_change_value.decrement()
             except ResourceError as re:
                 if re.status_int == 429:
-                    Scanner.sleep_change_value += self.increment_step
-                    logger.info("Received 429, will sleep for {}".format(Scanner.sleep_change_value))
+                    self.sleep_change_value.increment()
+                    logger.info("Received 429, will sleep for {}".format(self.sleep_change_value.time_between_requests))
                 else:
                     raise re
 

--- a/openprocurement/bot/identification/databridge/sleep_change_value.py
+++ b/openprocurement/bot/identification/databridge/sleep_change_value.py
@@ -1,0 +1,13 @@
+class APIRateController:
+    def __init__(self, increment_step=1, decrement_step=1):
+        self.increment_step = increment_step
+        self.decrement_step = decrement_step
+        self.time_between_requests = 0
+
+    def decrement(self):
+        self.time_between_requests -= self.decrement_step if self.decrement_step < self.time_between_requests else 0
+        return self.time_between_requests
+
+    def increment(self):
+        self.time_between_requests += self.increment_step
+        return self.time_between_requests

--- a/openprocurement/bot/identification/databridge/upload_file.py
+++ b/openprocurement/bot/identification/databridge/upload_file.py
@@ -26,9 +26,8 @@ class UploadFile(Greenlet):
 
     pre_qualification_procurementMethodType = ('aboveThresholdEU', 'competitiveDialogueUA', 'competitiveDialogueEU')
     qualification_procurementMethodType = ('aboveThresholdUA', 'aboveThresholdUA.defense', 'aboveThresholdEU', 'competitiveDialogueUA.stage2', 'competitiveDialogueEU.stage2')
-    sleep_change_value = 0
 
-    def __init__(self, client, upload_to_doc_service_queue, upload_to_tender_queue, processing_items, processed_items, doc_service_client, services_not_available, increment_step=1, decrement_step=1, delay=15):
+    def __init__(self, client, upload_to_doc_service_queue, upload_to_tender_queue, processing_items, processed_items, doc_service_client, services_not_available, sleep_change_value, delay=15):
         super(UploadFile, self).__init__()
         self.exit = False
         self.start_time = datetime.now()
@@ -45,9 +44,7 @@ class UploadFile(Greenlet):
         self.upload_to_doc_service_queue = upload_to_doc_service_queue
         self.upload_to_tender_queue = upload_to_tender_queue
 
-        self.increment_step = increment_step
-        self.decrement_step = decrement_step
-
+        self.sleep_change_value = sleep_change_value
         # retry queues for workers
         self.retry_upload_to_doc_service_queue = Queue(maxsize=500)
         self.retry_upload_to_tender_queue = Queue(maxsize=500)
@@ -180,7 +177,7 @@ class UploadFile(Greenlet):
                                                           "DOCUMENT_ID": document_id}))
                     self.update_processing_items(tender_data.tender_id, tender_data.item_id)
                     self.upload_to_tender_queue.get()
-                    UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                    self.sleep_change_value.decrement()
                     continue
                 elif re.status_int == 403 or re.status_int is None:
                     logger.warning("Accept {} while uploading to {} doc_id: {}. Message {}".format(
@@ -190,7 +187,7 @@ class UploadFile(Greenlet):
                                                "DOCUMENT_ID": document_id})
                     )
                     self.update_processing_items(tender_data.tender_id, tender_data.item_id)
-                    UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                    self.sleep_change_value.decrement()
                     self.upload_to_tender_queue.get()
                 elif re.status_int == 429:
                     logger.info("Accept 429 while uploading to tender {} {} {} doc_id: {}. Message {}".format(
@@ -198,7 +195,7 @@ class UploadFile(Greenlet):
                         extra=journal_context({"MESSAGE_ID": DATABRIDGE_ITEM_STATUS_CHANGED_WHILE_PROCESSING},
                                               {"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id,
                                                "DOCUMENT_ID": document_id}))
-                    UploadFile.sleep_change_value += self.increment_step
+                    self.sleep_change_value.increment()
                 else:
                     logger.warning('ResourceError while uploading file to {} doc_id: {}. Message: {}'.format(
                         data_string(tender_data), document_id, re.message),
@@ -207,7 +204,7 @@ class UploadFile(Greenlet):
                                                       "DOCUMENT_ID": document_id}))
                     self.retry_upload_to_tender_queue.put(tender_data)
                     self.upload_to_tender_queue.get()
-                    UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                    self.sleep_change_value.decrement()
             except Exception as e:
                 logger.info('Exception while uploading file to {} doc_id: {}. Message: {}'.format(
                     data_string(tender_data), document_id, e.message),
@@ -216,7 +213,7 @@ class UploadFile(Greenlet):
                                                   "DOCUMENT_ID": document_id}))
                 self.retry_upload_to_tender_queue.put(tender_data)
                 self.upload_to_tender_queue.get()
-                UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                self.sleep_change_value.decrement()
             else:
                 logger.info('Successfully uploaded file to {} doc_id: {}'.format(
                     data_string(tender_data), document_id),
@@ -226,8 +223,8 @@ class UploadFile(Greenlet):
                 # delete current tender after successful upload file (to avoid reloading file)
                 self.update_processing_items(tender_data.tender_id, tender_data.item_id)
                 self.upload_to_tender_queue.get()
-                UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
-            gevent.sleep(UploadFile.sleep_change_value)
+                self.sleep_change_value.decrement()
+            gevent.sleep(self.sleep_change_value.time_between_requests)
 
     def retry_upload_to_tender(self):
         """Get data from retry_upload_to_tender_queue; If upload was unsuccessful put Data obj back to
@@ -251,14 +248,14 @@ class UploadFile(Greenlet):
                                                          {"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id, "DOCUMENT_ID": document_id}))
                     self.update_processing_items(tender_data.tender_id, tender_data.item_id)
                     self.retry_upload_to_tender_queue.get()
-                    UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                    self.sleep_change_value.decrement()
                     continue
                 elif re.status_int == 429:
                     logger.info("Accept 429 while uploading to tender {} {} {} doc_id: {}. Message {}".format(
                         tender_data.tender_id, tender_data.item_name, tender_data.item_id, document_id, re.msg),
                         extra=journal_context({"MESSAGE_ID": DATABRIDGE_ITEM_STATUS_CHANGED_WHILE_PROCESSING},
                                               {"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id, "DOCUMENT_ID": document_id}))
-                    UploadFile.sleep_change_value += self.increment_step
+                    self.sleep_change_value.increment()
                 elif re.status_int == 403 or re.status_int is None:
                     logger.warning("Accept {} while uploading to {} doc_id: {}. Message {}".format(
                         re.status_int, data_string(tender_data), document_id, re.msg),
@@ -268,20 +265,21 @@ class UploadFile(Greenlet):
                     )
                     self.update_processing_items(tender_data.tender_id, tender_data.item_id)
                     self.retry_upload_to_tender_queue.get()
-                    UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                    self.sleep_change_value.decrement()
                     continue
                 else:
                     logger.info('ResourceError while retry uploading file to {} doc_id: {}. ResourceErrorStatus_int: {}. Message: {}'.format(
                         data_string(tender_data), document_id, re.status_int, re.message),
                         extra=journal_context({"MESSAGE_ID": DATABRIDGE_UNSUCCESS_RETRY_UPLOAD_TO_TENDER},
                                               params={"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id, "DOCUMENT_ID": document_id}))
+                    self.sleep_change_value.decrement()
             except Exception as e:
                 logger.info('Exception while retry uploading file to {} doc_id: {}. Message: {}'.format(
                     data_string(tender_data), document_id, e.message),
                     extra=journal_context({"MESSAGE_ID": DATABRIDGE_UNSUCCESS_RETRY_UPLOAD_TO_TENDER},
                                           params={"TENDER_ID": tender_data.tender_id, item_name_id: tender_data.item_id, "DOCUMENT_ID": document_id}))
                 logger.exception("Message: {}".format(e.message))
-                UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
+                self.sleep_change_value.decrement()
             else:
                 logger.info('Successfully uploaded file to {} doc_id: {} in retry'.format(
                     data_string(tender_data), document_id),
@@ -290,8 +288,8 @@ class UploadFile(Greenlet):
                 # delete current tender after successful upload file (to avoid reloading file)
                 self.update_processing_items(tender_data.tender_id, tender_data.item_id)
                 self.retry_upload_to_tender_queue.get()
-                UploadFile.sleep_change_value = UploadFile.sleep_change_value - self.decrement_step if self.decrement_step < UploadFile.sleep_change_value else 0
-            gevent.sleep(UploadFile.sleep_change_value)
+                self.sleep_change_value.decrement()
+            gevent.sleep(self.sleep_change_value.time_between_requests)
 
     @retry(stop_max_attempt_number=5, wait_exponential_multiplier=1000)
     def client_upload_to_tender(self, tender_data):

--- a/openprocurement/bot/identification/tests/bridge.py
+++ b/openprocurement/bot/identification/tests/bridge.py
@@ -116,8 +116,7 @@ class TestBridgeWorker(BaseServersTest):
     def test_init(self):
         self.worker = EdrDataBridge(config)
         self.assertEqual(self.worker.delay, 15)
-        self.assertEqual(self.worker.increment_step, 1)
-        self.assertEqual(self.worker.decrement_step, 1)
+        self.assertEqual(self.worker.sleep_change_value.time_between_requests, 0)
 
         # check clients
         self.assertTrue(isinstance(self.worker.tenders_sync_client, TendersClientSync))

--- a/openprocurement/bot/identification/tests/edr_handler.py
+++ b/openprocurement/bot/identification/tests/edr_handler.py
@@ -23,6 +23,7 @@ from openprocurement.bot.identification.tests.utils import custom_sleep, generat
     ResponseMock
 from openprocurement.bot.identification.client import ProxyClient
 from openprocurement.bot.identification.databridge.constants import version, author
+from openprocurement.bot.identification.databridge.sleep_change_value import APIRateController
 
 
 def get_random_edr_ids(count=1):
@@ -49,6 +50,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
         self.processing_items = {}
         self.worker = EdrHandler.spawn(self.proxy_client, self.edrpou_codes_queue,
                                        self.upload_to_doc_service_queue, self.processing_items, MagicMock())
+        self.sleep_change_value = APIRateController()
 
     def meta(self):
         return {'meta': {'id': self.document_id, 'author': author, 'sourceRequests': [
@@ -528,7 +530,7 @@ class TestEdrHandlerWorker(unittest.TestCase):
                                                                                   }]}, ]}}))
         mrequest.get(self.url, [self.stat_200([{}], self.source_date, edr_req_id)])
         filter_tenders_worker = FilterTenders.spawn(client, filtered_tender_ids_queue, edrpou_codes_queue, {},
-                                                    MagicMock(), {})
+                                                    MagicMock(), {}, self.sleep_change_value)
         self.worker = EdrHandler.spawn(self.proxy_client, edrpou_codes_queue, upload_to_doc_service_queue,
                                        MagicMock(), MagicMock())
 


### PR DESCRIPTION
Додано контроль за інтенсивністю запитів до ЦБД, винесено в окремий клас `APIRateController` через те, що логіка була ідентичною в усих класах, що працювали з ЦБД. Таким чином, централізовано контроль, що допоможе уникнути ситуацій, коли один з класів отримав повідомлення про необхідність у збільшенні інтервалу між запитами, але інші класи цього "не знали".

fixes #72 